### PR TITLE
Feat: 내 정보 가져오기, 엑세스 토큰 재발급 기능 구현 완료

### DIFF
--- a/src/main/java/login/jungmae/login/config/SecurityConfig.java
+++ b/src/main/java/login/jungmae/login/config/SecurityConfig.java
@@ -61,9 +61,10 @@ public class SecurityConfig {
 
         // request 에 대한 인증 인가 설정
         http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-                .requestMatchers("oauth2/user/**").hasAnyRole("USER","ADMIN")
+//                .requestMatchers("oauth2/user/**").hasAnyRole("USER","ADMIN")
                 .requestMatchers("oauth2/manager/**").hasRole("ADMIN")
                 .requestMatchers("api/v1/admin/**").hasRole("ADMIN")
+                .requestMatchers("oauth2/token/**").permitAll()
                 .anyRequest().permitAll()
         );
 

--- a/src/main/java/login/jungmae/login/config/jwt/JwtProperties.java
+++ b/src/main/java/login/jungmae/login/config/jwt/JwtProperties.java
@@ -3,7 +3,9 @@ package login.jungmae.login.config.jwt;
 public interface JwtProperties {
 
     String SECRET = "kan";
-    int EXPIRATION_TIME = 60000 * 10 * 10;   // 10분 * 10
+    int ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60;   // 1분
+    int REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7;    // 7일
+
     String TOKEN_PREFIX = "Bearer ";
     String HEADER_STRING = "Authorization";
 }

--- a/src/main/java/login/jungmae/login/domain/User.java
+++ b/src/main/java/login/jungmae/login/domain/User.java
@@ -4,10 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.sql.Timestamp;
@@ -15,7 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-@Data
+@Getter
 @Entity
 @Builder
 @NoArgsConstructor

--- a/src/main/java/login/jungmae/login/domain/dto/UserDto.java
+++ b/src/main/java/login/jungmae/login/domain/dto/UserDto.java
@@ -1,0 +1,31 @@
+package login.jungmae.login.domain.dto;
+
+import login.jungmae.login.domain.User;
+import lombok.Builder;
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+public class UserDto {
+    private String username;
+    private String name;
+    private String password;
+    private String email;
+    private String role;
+
+    private String provider;
+
+    private Timestamp createDate;
+
+
+    public UserDto(User user) {
+        this.username = user.getUsername();
+        this.name = user.getName();
+        this.password = user.getPassword();
+        this.email = user.getEmail();
+        this.role = user.getRole();
+        this.provider = user.getProvider();
+        this.createDate = user.getCreateDate();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create #create update none
+      ddl-auto: update #create update none
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true


### PR DESCRIPTION
내정보 가져오기
    유저 토큰(엑세스토큰과 리프레쉬토큰)을 만들어 Client에게 HttpServletResponse를 사용해 헤더로 반환
        1. 가져온 OAuth데이터의 AccessToken 을 사용해 유저의 OAuth 프로필 정보를 가져온다.
        2. OAuth 프로필 정보를 사용해 로그인 이력이 없다면 유저정보를 만들어 디비에 저장하고 로그인 이력이 있다면 유저 정보를 가져온다.
        3. 유저 정보를 사용해 AccessToken과 RefreshToken을 만들어 Client에게 반환한다. (Json 형태로 반환함.)
엑세스 토큰 재발급
    Client에게 refreshToken을 받아 accessToken을 재발급해 반환함.